### PR TITLE
Add summary at the end of the ndt5 test

### DIFF
--- a/cmd/ndt5-client/internal/emitter/emitter.go
+++ b/cmd/ndt5-client/internal/emitter/emitter.go
@@ -1,4 +1,4 @@
-// Package emitter contains the ndt7-client emitter.
+// Package emitter contains the ndt5-client emitter.
 package emitter
 
 // Emitter is a generic emitter. When an event occurs, the

--- a/cmd/ndt5-client/internal/emitter/emitter.go
+++ b/cmd/ndt5-client/internal/emitter/emitter.go
@@ -22,7 +22,7 @@ type Emitter interface {
 	// OnInfo is emitted on info messages.
 	OnInfo(string) error
 
-	// OnUploadEvent is emitted during the upload.
+	// OnSpeed is emitted during the upload.
 	OnSpeed(string, string) error
 
 	// OnSummary is emitted after the test is over.

--- a/cmd/ndt5-client/internal/emitter/emitter.go
+++ b/cmd/ndt5-client/internal/emitter/emitter.go
@@ -1,0 +1,30 @@
+// Package emitter contains the ndt7-client emitter.
+package emitter
+
+// Emitter is a generic emitter. When an event occurs, the
+// corresponding method will be called. An error will generally
+// mean that it's not possible to write the output. A common
+// case where this happen is where the output is redirected to
+// a file on a full hard disk.
+//
+// See the documentation of the main package for more details
+// on the sequence in which events may occur.
+type Emitter interface {
+	// OnDebug is emitted on debug messages.
+	OnDebug(string) error
+
+	// OnError is emitted on error mesages.
+	OnError(string) error
+
+	// OnWarning is emitted on warning messages.
+	OnWarning(string) error
+
+	// OnInfo is emitted on info messages.
+	OnInfo(string) error
+
+	// OnUploadEvent is emitted during the upload.
+	OnSpeed(string, string) error
+
+	// OnSummary is emitted after the test is over.
+	OnSummary(s *Summary) error
+}

--- a/cmd/ndt5-client/internal/emitter/humanreadable.go
+++ b/cmd/ndt5-client/internal/emitter/humanreadable.go
@@ -1,0 +1,77 @@
+package emitter
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// HumanReadable is a human readable emitter. It emits the events generated
+// by running a ndt7 test as pleasant stdout messages.
+type HumanReadable struct {
+	out io.Writer
+}
+
+// NewHumanReadable returns a new human readable emitter.
+func NewHumanReadable() Emitter {
+	return HumanReadable{os.Stdout}
+}
+
+// NewHumanReadableWithWriter returns a new human readable emitter using the
+// specified writer.
+func NewHumanReadableWithWriter(w io.Writer) Emitter {
+	return HumanReadable{w}
+}
+
+// OnDebug handles debug messages.
+func (h HumanReadable) OnDebug(m string) error {
+	_, err := fmt.Fprintf(h.out, "\r%s\n", m)
+	return err
+}
+
+// OnError handles error messages.
+func (h HumanReadable) OnError(m string) error {
+	_, failure := fmt.Fprintf(h.out, "\r%s\n", m)
+	return failure
+}
+
+// OnWarning handles warning messages.
+func (h HumanReadable) OnWarning(m string) error {
+	_, err := fmt.Fprintf(h.out, "\r%s\n", m)
+	return err
+}
+
+// OnInfo handles info messages.
+func (h HumanReadable) OnInfo(m string) error {
+	_, err := fmt.Fprintf(h.out, "\r%s\n", m)
+	return err
+}
+
+// OnSpeed handles a speed reporting event during a test.
+func (h HumanReadable) OnSpeed(test string, speed string) error {
+	_, err := fmt.Fprintf(h.out, "\r%s: %s\n", test, speed)
+	return err
+}
+
+// OnSummary handles the summary event.
+func (h HumanReadable) OnSummary(s *Summary) error {
+	const summaryFormat = `%15s: %s
+%15s: %s
+%15s: %7.1f %s
+%15s: %7.1f %s
+%15s: %7.1f %s
+%15s: %7.2f %s
+`
+	_, err := fmt.Fprintf(h.out, summaryFormat,
+		"Server", s.Server,
+		"Client", s.Client,
+		"Latency", s.RTT.Value, s.RTT.Unit,
+		"Download", s.Download.Value, s.Upload.Unit,
+		"Upload", s.Upload.Value, s.Upload.Unit,
+		"Retransmission", s.DownloadRetrans.Value, s.DownloadRetrans.Unit)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/ndt5-client/internal/emitter/humanreadable.go
+++ b/cmd/ndt5-client/internal/emitter/humanreadable.go
@@ -7,7 +7,7 @@ import (
 )
 
 // HumanReadable is a human readable emitter. It emits the events generated
-// by running a ndt7 test as pleasant stdout messages.
+// by running a ndt5 test as pleasant stdout messages.
 type HumanReadable struct {
 	out io.Writer
 }

--- a/cmd/ndt5-client/internal/emitter/humanreadable_test.go
+++ b/cmd/ndt5-client/internal/emitter/humanreadable_test.go
@@ -1,0 +1,166 @@
+package emitter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/m-lab/ndt5-client-go/cmd/ndt5-client/internal/mocks"
+)
+
+func TestHumanReadableOnDebug(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	hr := HumanReadable{sw}
+	err := hr.OnDebug("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sw.Data[0]) != "\rtest\n" {
+		t.Fatal("OnDebug(): unexpected output")
+	}
+
+	hr = HumanReadable{&mocks.FailingWriter{}}
+	err = hr.OnDebug("test")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestHumanReadableOnError(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	hr := HumanReadable{sw}
+	err := hr.OnError("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sw.Data[0]) != "\rtest\n" {
+		t.Fatal("OnDebug(): unexpected output")
+	}
+
+	hr = HumanReadable{&mocks.FailingWriter{}}
+	err = hr.OnError("test")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestHumanReadableOnWarning(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	hr := HumanReadable{sw}
+	err := hr.OnWarning("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sw.Data[0]) != "\rtest\n" {
+		t.Fatal("OnDebug(): unexpected output")
+	}
+
+	hr = HumanReadable{&mocks.FailingWriter{}}
+	err = hr.OnWarning("test")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestHumanReadableOnInfo(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	hr := HumanReadable{sw}
+	err := hr.OnInfo("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sw.Data[0]) != "\rtest\n" {
+		t.Fatal("OnDebug(): unexpected output")
+	}
+
+	hr = HumanReadable{&mocks.FailingWriter{}}
+	err = hr.OnInfo("test")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestHumanReadableOnSpeed(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	hr := HumanReadable{sw}
+	err := hr.OnSpeed("test", "speed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sw.Data[0]) != "\rtest: speed\n" {
+		t.Fatal("OnDebug(): unexpected output")
+	}
+
+	hr = HumanReadable{&mocks.FailingWriter{}}
+	err = hr.OnSpeed("test", "speed")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestHumanReadableOnSummary(t *testing.T) {
+	expected := `         Server: test
+         Client: test
+        Latency:    10.0 ms
+       Download:   100.0 Mbit/s
+         Upload:   100.0 Mbit/s
+ Retransmission:    1.00 %
+`
+	summary := &Summary{
+		Client: "test",
+		Server: "test",
+		Download: ValueUnitPair{
+			Value: 100.0,
+			Unit:  "Mbit/s",
+		},
+		Upload: ValueUnitPair{
+			Value: 100.0,
+			Unit:  "Mbit/s",
+		},
+		DownloadRetrans: ValueUnitPair{
+			Value: 1.0,
+			Unit:  "%",
+		},
+		RTT: ValueUnitPair{
+			Value: 10.0,
+			Unit:  "ms",
+		},
+	}
+	sw := &mocks.SavingWriter{}
+	j := HumanReadable{sw}
+	err := j.OnSummary(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sw.Data) != 1 {
+		t.Fatal("invalid length")
+	}
+	if string(sw.Data[0]) != expected {
+		fmt.Println(string(sw.Data[0]))
+		fmt.Println(expected)
+		t.Fatal("OnSummary(): unexpected data")
+	}
+}
+
+func TestHumanReadableOnSummaryFailure(t *testing.T) {
+	sw := &mocks.FailingWriter{}
+	j := HumanReadable{sw}
+	err := j.OnSummary(&Summary{})
+	if err == nil {
+		t.Fatal("OnSummary(): expected err, got nil")
+	}
+}
+
+func TestNewHumanReadableConstructor(t *testing.T) {
+	hr := NewHumanReadable()
+	if hr == nil {
+		t.Fatal("NewHumanReadable() did not return a HumanReadable")
+	}
+}
+
+func TestNewHumanReadableWithWriter(t *testing.T) {
+	hr := NewHumanReadableWithWriter(&mocks.SavingWriter{})
+	if hr == nil {
+		t.Fatal("NewHumanReadableWithWriter() did not return a HumanReadable")
+	}
+}

--- a/cmd/ndt5-client/internal/emitter/json.go
+++ b/cmd/ndt5-client/internal/emitter/json.go
@@ -4,12 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-
-	"github.com/m-lab/ndt7-client-go/spec"
 )
 
 // jsonEmitter is a jsonEmitter emitter. It emits messages consistent with
-// the cmd/ndt7-client/main.go documentation for `-format=json`.
+// the cmd/ndt5-client/main.go documentation for `-format=json`.
 type jsonEmitter struct {
 	io.Writer
 }
@@ -35,12 +33,6 @@ func (j jsonEmitter) emitInterface(any interface{}) error {
 type batchEvent struct {
 	Key   string
 	Value interface{}
-}
-
-type batchValue struct {
-	spec.Measurement
-	Failure string `json:",omitempty"`
-	Server  string `json:",omitempty"`
 }
 
 // OnDebug emits debug events.

--- a/cmd/ndt5-client/internal/emitter/json.go
+++ b/cmd/ndt5-client/internal/emitter/json.go
@@ -1,0 +1,89 @@
+package emitter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/m-lab/ndt7-client-go/spec"
+)
+
+// jsonEmitter is a jsonEmitter emitter. It emits messages consistent with
+// the cmd/ndt7-client/main.go documentation for `-format=json`.
+type jsonEmitter struct {
+	io.Writer
+}
+
+// NewJSON creates a new JSON emitter
+func NewJSON(w io.Writer) Emitter {
+	return jsonEmitter{w}
+}
+
+func (j jsonEmitter) emitData(data []byte) error {
+	_, err := j.Write(append(data, byte('\n')))
+	return err
+}
+
+func (j jsonEmitter) emitInterface(any interface{}) error {
+	data, err := json.Marshal(any)
+	if err != nil {
+		return err
+	}
+	return j.emitData(data)
+}
+
+type batchEvent struct {
+	Key   string
+	Value interface{}
+}
+
+type batchValue struct {
+	spec.Measurement
+	Failure string `json:",omitempty"`
+	Server  string `json:",omitempty"`
+}
+
+// OnDebug emits debug events.
+func (j jsonEmitter) OnDebug(m string) error {
+	return j.emitInterface(batchEvent{
+		Key:   "debug",
+		Value: m,
+	})
+}
+
+// OnError emits error events.
+func (j jsonEmitter) OnError(m string) error {
+	return j.emitInterface(batchEvent{
+		Key:   "error",
+		Value: m,
+	})
+}
+
+// OnWarning emits warning events.
+func (j jsonEmitter) OnWarning(m string) error {
+	return j.emitInterface(batchEvent{
+		Key:   "warning",
+		Value: m,
+	})
+}
+
+// OnInfo emits info events.
+func (j jsonEmitter) OnInfo(m string) error {
+	return j.emitInterface(batchEvent{
+		Key:   "info",
+		Value: m,
+	})
+}
+
+// OnSpeed emits speed events.
+func (j jsonEmitter) OnSpeed(test string, speed string) error {
+	return j.emitInterface(batchEvent{
+		Key:   "speed",
+		Value: fmt.Sprintf("%s: %s", test, speed),
+	})
+}
+
+// OnSummary handles the summary event, emitted after the test is over.
+func (j jsonEmitter) OnSummary(s *Summary) error {
+	return j.emitInterface(s)
+}

--- a/cmd/ndt5-client/internal/emitter/json_test.go
+++ b/cmd/ndt5-client/internal/emitter/json_test.go
@@ -1,0 +1,218 @@
+package emitter
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/m-lab/ndt5-client-go/cmd/ndt5-client/internal/mocks"
+)
+
+func TestJSONOnDebug(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	j := NewJSON(sw)
+	err := j.OnDebug("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 1 {
+		t.Fatal("invalid length")
+	}
+	var event struct {
+		Key   string
+		Value string
+	}
+	err = json.Unmarshal(sw.Data[0], &event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Key != "debug" {
+		t.Fatal("Unexpected event key")
+	}
+	if event.Value != "test" {
+		t.Fatal("Unexpected event value")
+	}
+
+	j = NewJSON(&mocks.FailingWriter{})
+	err = j.OnDebug("test")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestJSONOnError(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	j := NewJSON(sw)
+	err := j.OnError("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 1 {
+		t.Fatal("invalid length")
+	}
+	var event struct {
+		Key   string
+		Value string
+	}
+	err = json.Unmarshal(sw.Data[0], &event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Key != "error" {
+		t.Fatal("Unexpected event key")
+	}
+	if event.Value != "test" {
+		t.Fatal("Unexpected event value")
+	}
+
+	j = NewJSON(&mocks.FailingWriter{})
+	err = j.OnError("test")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestJSONOnWarning(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	j := NewJSON(sw)
+	err := j.OnWarning("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 1 {
+		t.Fatal("invalid length")
+	}
+	var event struct {
+		Key   string
+		Value string
+	}
+	err = json.Unmarshal(sw.Data[0], &event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Key != "warning" {
+		t.Fatal("Unexpected event key")
+	}
+	if event.Value != "test" {
+		t.Fatal("Unexpected event value")
+	}
+
+	j = NewJSON(&mocks.FailingWriter{})
+	err = j.OnWarning("test")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestJSONOnInfo(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	j := NewJSON(sw)
+	err := j.OnInfo("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 1 {
+		t.Fatal("invalid length")
+	}
+	var event struct {
+		Key   string
+		Value string
+	}
+	err = json.Unmarshal(sw.Data[0], &event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Key != "info" {
+		t.Fatal("Unexpected event key")
+	}
+	if event.Value != "test" {
+		t.Fatal("Unexpected event value")
+	}
+
+	j = NewJSON(&mocks.FailingWriter{})
+	err = j.OnInfo("test")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestJSONOnSpeed(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	j := NewJSON(sw)
+	err := j.OnSpeed("test", "speed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 1 {
+		t.Fatal("invalid length")
+	}
+	var event struct {
+		Key   string
+		Value string
+	}
+	err = json.Unmarshal(sw.Data[0], &event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Key != "speed" {
+		t.Fatal("Unexpected event key")
+	}
+	if event.Value != "test: speed" {
+		t.Fatal("Unexpected event value")
+	}
+
+	j = NewJSON(&mocks.FailingWriter{})
+	err = j.OnSpeed("test", "speed")
+	if err != mocks.ErrMocked {
+		t.Fatal("Not the error we expected")
+	}
+}
+
+func TestNewJSONConstructor(t *testing.T) {
+	if NewJSON(&mocks.SavingWriter{}) == nil {
+		t.Fatal("NewJSONWithWriter did not return an Emitter")
+	}
+}
+
+func TestEmitInterfaceFailure(t *testing.T) {
+	j := jsonEmitter{Writer: os.Stdout}
+	// See https://stackoverflow.com/a/48901259
+	x := map[string]interface{}{
+		"foo": make(chan int),
+	}
+	err := j.emitInterface(x)
+	switch err.(type) {
+	case *json.UnsupportedTypeError:
+		// nothing
+	default:
+		t.Fatal("Expected a json.UnsupportedTypeError here")
+	}
+}
+
+func TestJSONOnSummary(t *testing.T) {
+	summary := &Summary{}
+	sw := &mocks.SavingWriter{}
+	j := NewJSON(sw)
+	err := j.OnSummary(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 1 {
+		t.Fatal("invalid length")
+	}
+
+	var output Summary
+	err = json.Unmarshal(sw.Data[0], &output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output.Client != summary.Client ||
+		output.Server != summary.Server ||
+		output.Download != summary.Download ||
+		output.Upload != summary.Upload ||
+		output.DownloadRetrans != summary.DownloadRetrans ||
+		output.RTT != summary.RTT {
+		t.Fatal("OnSummary(): unexpected output")
+	}
+
+}

--- a/cmd/ndt5-client/internal/emitter/quiet.go
+++ b/cmd/ndt5-client/internal/emitter/quiet.go
@@ -1,0 +1,46 @@
+package emitter
+
+// Quiet acts as a filter allowing summary and error messages only, and
+// doesn't perform any formatting.
+// The message is actually emitted by the embedded Emitter.
+type Quiet struct {
+	emitter Emitter
+}
+
+// NewQuiet returns a Summary emitter which emits messages
+// via the passed Emitter.
+func NewQuiet(e Emitter) Emitter {
+	return &Quiet{
+		emitter: e,
+	}
+}
+
+// OnDebug does not emit anything.
+func (q Quiet) OnDebug(string) error {
+	return nil
+}
+
+// OnError emits the error event.
+func (q Quiet) OnError(m string) error {
+	return q.emitter.OnError(m)
+}
+
+// OnWarning does not emit anything.
+func (q Quiet) OnWarning(string) error {
+	return nil
+}
+
+// OnInfo does not emit anything.
+func (q Quiet) OnInfo(string) error {
+	return nil
+}
+
+// OnSpeed does not emit anything.
+func (q Quiet) OnSpeed(string, string) error {
+	return nil
+}
+
+// OnSummary handles the summary event, emitted after the test is over.
+func (q Quiet) OnSummary(s *Summary) error {
+	return q.emitter.OnSummary(s)
+}

--- a/cmd/ndt5-client/internal/emitter/quiet_test.go
+++ b/cmd/ndt5-client/internal/emitter/quiet_test.go
@@ -1,0 +1,90 @@
+package emitter
+
+import (
+	"os"
+	"testing"
+
+	"github.com/m-lab/ndt5-client-go/cmd/ndt5-client/internal/mocks"
+)
+
+func TestNewQuiet(t *testing.T) {
+	e := jsonEmitter{os.Stdout}
+	if NewQuiet(e) == nil {
+		t.Fatal("NewQuiet() did not return an Emitter")
+	}
+}
+
+func TestQuiet_OnDebug(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	e := jsonEmitter{sw}
+	quiet := Quiet{e}
+	err := quiet.OnDebug("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 0 {
+		t.Fatal("OnStarting(): unexpected data")
+	}
+}
+
+func TestQuiet_OnError(t *testing.T) {
+	// The only thing to test here is that errors from the underlying emitter
+	// are passed back to the caller.
+	sw := &mocks.FailingWriter{}
+	e := jsonEmitter{sw}
+	quiet := Quiet{e}
+	err := quiet.OnError("test")
+	if err != mocks.ErrMocked {
+		t.Fatal("OnError(): unexpected error type or nil")
+	}
+}
+
+func TestQuiet_OnWarning(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	e := jsonEmitter{sw}
+	quiet := Quiet{e}
+	err := quiet.OnWarning("download")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 0 {
+		t.Fatal("OnConnected(): unexpected data")
+	}
+}
+
+func TestQuiet_OnInfo(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	e := jsonEmitter{sw}
+	quiet := Quiet{e}
+	err := quiet.OnInfo("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 0 {
+		t.Fatal("OnDownloadEvent(): unexpected data")
+	}
+}
+
+func TestQuiet_OnSpeed(t *testing.T) {
+	sw := &mocks.SavingWriter{}
+	e := jsonEmitter{sw}
+	quiet := Quiet{e}
+	err := quiet.OnSpeed("test", "speed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 0 {
+		t.Fatal("OnUploadEvent(): unexpected data")
+	}
+}
+func TestQuiet_OnSummary(t *testing.T) {
+	// The only thing to test here is that errors from the underlying emitter
+	// are passed back to the caller.
+	sw := &mocks.FailingWriter{}
+	e := jsonEmitter{sw}
+	quiet := Quiet{e}
+	err := quiet.OnSummary(&Summary{})
+	if err != mocks.ErrMocked {
+		t.Fatal("OnSummary(): unexpected error type or nil")
+	}
+}

--- a/cmd/ndt5-client/internal/emitter/summary.go
+++ b/cmd/ndt5-client/internal/emitter/summary.go
@@ -1,0 +1,39 @@
+package emitter
+
+// ValueUnitPair represents a {"Value": ..., "Unit": ...} pair.
+type ValueUnitPair struct {
+	Value float64
+	Unit  string
+}
+
+// Summary is a struct containing the values displayed to the user at
+// the end of an ndt7 test.
+type Summary struct {
+	// Server is the FQDN of the server used for this test.
+	Server string
+
+	// Client is the IP address of the client.
+	Client string
+
+	// Download is the download speed, in Mbit/s. This is measured at the
+	// receiver.
+	Download ValueUnitPair
+
+	// Upload is the upload speed, in Mbit/s. This is measured at the sender.
+	Upload ValueUnitPair
+
+	// DownloadRetrans is the retransmission rate. This is based on the TCPInfo
+	// values provided by the server during a download test.
+	DownloadRetrans ValueUnitPair
+
+	// RTT is the round-trip time of the latest measurement, in milliseconds.
+	// This is provided by the server during a download test.
+	RTT ValueUnitPair
+}
+
+// NewSummary returns a new Summary struct for a given FQDN.
+func NewSummary(FQDN string) *Summary {
+	return &Summary{
+		Server: FQDN,
+	}
+}

--- a/cmd/ndt5-client/internal/emitter/summary.go
+++ b/cmd/ndt5-client/internal/emitter/summary.go
@@ -7,7 +7,7 @@ type ValueUnitPair struct {
 }
 
 // Summary is a struct containing the values displayed to the user at
-// the end of an ndt7 test.
+// the end of an ndt5 test.
 type Summary struct {
 	// Server is the FQDN of the server used for this test.
 	Server string

--- a/cmd/ndt5-client/internal/emitter/summary_test.go
+++ b/cmd/ndt5-client/internal/emitter/summary_test.go
@@ -1,0 +1,15 @@
+package emitter
+
+import (
+	"testing"
+)
+
+func TestNewSummary(t *testing.T) {
+	s := NewSummary("test")
+	if s == nil {
+		t.Fatal("NewSummary() did not return a Summary")
+	}
+	if s.Server != "test" {
+		t.Fatal("NewSummary(): unexpected Server field")
+	}
+}

--- a/cmd/ndt5-client/internal/mocks/mocks.go
+++ b/cmd/ndt5-client/internal/mocks/mocks.go
@@ -1,0 +1,28 @@
+// Package mocks contains mocks
+package mocks
+
+import (
+	"errors"
+)
+
+// ErrMocked is a mocked error
+var ErrMocked = errors.New("mocked error")
+
+// FailingWriter is a writer that always fails
+type FailingWriter struct{}
+
+// Write always returns a mocked error
+func (FailingWriter) Write([]byte) (int, error) {
+	return 0, ErrMocked
+}
+
+// SavingWriter is a writer that saves what it's passed
+type SavingWriter struct {
+	Data [][]byte
+}
+
+// Write appends data to sw.Data. It never fails.
+func (sw *SavingWriter) Write(data []byte) (int, error) {
+	sw.Data = append(sw.Data, data)
+	return len(data), nil
+}

--- a/cmd/ndt5-client/internal/mocks/mocks_test.go
+++ b/cmd/ndt5-client/internal/mocks/mocks_test.go
@@ -1,0 +1,46 @@
+package mocks
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFailingWriter(t *testing.T) {
+	wr := FailingWriter{}
+	n, err := wr.Write([]byte("abc"))
+	if n != 0 {
+		t.Fatal("Expected zero bytes here")
+	}
+	if err != ErrMocked {
+		t.Fatal("Expected an ErrMocked here")
+	}
+}
+
+func TestSavingWriter(t *testing.T) {
+	sw := &SavingWriter{}
+	first := []byte("abc")
+	n, err := sw.Write(first)
+	if n != len(first) {
+		t.Fatal("Unexpected length")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := []byte("de")
+	n, err = sw.Write(second)
+	if n != len(second) {
+		t.Fatal("Unexpected length")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sw.Data) != 2 {
+		t.Fatal("Unexpected data length")
+	}
+	if !reflect.DeepEqual(sw.Data[0], first) {
+		t.Fatal("First write is not equal")
+	}
+	if !reflect.DeepEqual(sw.Data[1], second) {
+		t.Fatal("Second write is not equal")
+	}
+}

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -6,12 +6,15 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/ndt5-client-go"
+	"github.com/m-lab/ndt5-client-go/cmd/ndt5-client/internal/emitter"
 	"github.com/m-lab/ndt5-client-go/internal/trafficshaping"
 )
 
@@ -60,37 +63,85 @@ func main() {
 	client := ndt5.NewClient(clientName, clientVersion)
 	client.ProtocolFactory = factory5
 	client.FQDN = *flagHostname
+
+	e := emitter.NewJSON(os.Stdout)
+
 	ctx, cancel := context.WithTimeout(context.Background(), *flagTimeout)
 	defer cancel()
 	out, err := client.Start(ctx)
 	rtx.Must(err, "client.Start failed")
-	var extra string
 	for ev := range out {
 		if ev.DebugMessage != nil {
-			fmt.Printf("%s%s\n", extra, strings.Trim(ev.DebugMessage.Message, "\t\n "))
-			extra = ""
+			e.OnDebug(strings.Trim(ev.DebugMessage.Message, "\t\n "))
 		}
 		if ev.InfoMessage != nil {
-			fmt.Printf("%s%s\n", extra, strings.Trim(ev.InfoMessage.Message, "\t\n "))
-			extra = ""
+			e.OnInfo(strings.Trim(ev.InfoMessage.Message, "\t\n "))
 		}
 		if ev.WarningMessage != nil {
-			fmt.Printf("%swarning: %s\n", extra, ev.WarningMessage.Error.Error())
-			extra = ""
+			e.OnWarning(ev.WarningMessage.Error.Error())
 		}
 		if ev.ErrorMessage != nil {
-			fmt.Printf("%serror: %s\n", extra, ev.ErrorMessage.Error.Error())
-			extra = ""
+			e.OnError(ev.ErrorMessage.Error.Error())
 		}
 		if ev.CurDownloadSpeed != nil {
-			fmt.Printf("\rdownload: %s", computeSpeed(ev.CurDownloadSpeed))
-			extra = "\n"
+			e.OnSpeed("download", computeSpeed(ev.CurDownloadSpeed))
 		}
 		if ev.CurUploadSpeed != nil {
-			fmt.Printf("\rupload:   %s", computeSpeed(ev.CurUploadSpeed))
-			extra = "\n"
+			e.OnSpeed("upload", computeSpeed(ev.CurUploadSpeed))
 		}
 	}
+
+	summary := makeSummary(client.FQDN, client.Result)
+	e.OnSummary(summary)
+}
+
+func makeSummary(FQDN string, result ndt5.TestResult) *emitter.Summary {
+	s := emitter.NewSummary(FQDN)
+
+	if clientIP, ok := result.Web100["NDTResult.S2C.ClientIP"]; ok {
+		s.Client = clientIP
+	}
+
+	elapsed := result.ClientMeasuredDownload.Elapsed.Nanoseconds()
+	s.Download = emitter.ValueUnitPair{
+		Value: (8.0 * float64(result.ClientMeasuredDownload.Count)) /
+			float64(elapsed),
+		Unit: "Mbit/s",
+	}
+
+	s.Upload = emitter.ValueUnitPair{
+		// Upload coming from the NDT server is in kbit/second.
+		Value: result.ServerMeasuredUpload / 1000,
+		Unit:  "Mbit/s",
+	}
+
+	// Here we use the RTT provided by the server, assuming they are
+	// symmetrical.
+	if rtt, ok := result.Web100["TCPInfo.RTT"]; ok {
+		rtt, err := strconv.ParseFloat(rtt, 64)
+		if err == nil {
+			s.RTT = emitter.ValueUnitPair{
+				// TCPInfo.RTT is in microseconds.
+				Value: rtt / 1000.0,
+				Unit:  "ms",
+			}
+		}
+	}
+
+	if bytesRetrans, ok := result.Web100["TCPInfo.BytesRetrans"]; ok {
+		if bytesSent, ok := result.Web100["TCPInfo.BytesSent"]; ok {
+			retrans, err1 := strconv.ParseFloat(bytesRetrans, 64)
+			sent, err2 := strconv.ParseFloat(bytesSent, 64)
+
+			if err1 == nil && err2 == nil {
+				s.DownloadRetrans = emitter.ValueUnitPair{
+					Value: retrans / sent * 100,
+					Unit:  "%",
+				}
+			}
+		}
+	}
+	return s
 }
 
 func computeSpeed(speed *ndt5.Speed) string {


### PR DESCRIPTION
This PR introduces a summary at the end of the NDT test, which is very similar to [the one in ndt7-client-go](https://github.com/m-lab/ndt7-client-go/pull/39).

To make the output configurable, `-format <human|json>` and `-quiet` have been added here, too.

Also, the Emitter interface and concrete implementations logic has been borrowed from the ndt7 client, but the interface is radically different due to the different types of events that the ndt5 Client can emit.

The summary format has been intentionally kept the same between the ndt5 and ndt7 client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt5-client-go/3)
<!-- Reviewable:end -->
