### PR TITLE
ServerFQDN, ServerIP/ClientIP, MinRTT and add DownloadUUID

### DIFF
--- a/cmd/ndt5-client/internal/emitter/humanreadable.go
+++ b/cmd/ndt5-client/internal/emitter/humanreadable.go
@@ -63,9 +63,9 @@ func (h HumanReadable) OnSummary(s *Summary) error {
 %15s: %7.2f %s
 `
 	_, err := fmt.Fprintf(h.out, summaryFormat,
-		"Server", s.Server,
-		"Client", s.Client,
-		"Latency", s.RTT.Value, s.RTT.Unit,
+		"Server", s.ServerFQDN,
+		"Client", s.ClientIP,
+		"Latency", s.MinRTT.Value, s.MinRTT.Unit,
 		"Download", s.Download.Value, s.Upload.Unit,
 		"Upload", s.Upload.Value, s.Upload.Unit,
 		"Retransmission", s.DownloadRetrans.Value, s.DownloadRetrans.Unit)

--- a/cmd/ndt5-client/internal/emitter/humanreadable_test.go
+++ b/cmd/ndt5-client/internal/emitter/humanreadable_test.go
@@ -106,8 +106,8 @@ func TestHumanReadableOnSummary(t *testing.T) {
  Retransmission:    1.00 %
 `
 	summary := &Summary{
-		Client: "test",
-		Server: "test",
+		ClientIP:   "test",
+		ServerFQDN: "test",
 		Download: ValueUnitPair{
 			Value: 100.0,
 			Unit:  "Mbit/s",
@@ -120,7 +120,7 @@ func TestHumanReadableOnSummary(t *testing.T) {
 			Value: 1.0,
 			Unit:  "%",
 		},
-		RTT: ValueUnitPair{
+		MinRTT: ValueUnitPair{
 			Value: 10.0,
 			Unit:  "ms",
 		},

--- a/cmd/ndt5-client/internal/emitter/json_test.go
+++ b/cmd/ndt5-client/internal/emitter/json_test.go
@@ -208,6 +208,8 @@ func TestJSONOnSummary(t *testing.T) {
 	}
 	if output.ClientIP != summary.ClientIP ||
 		output.ServerFQDN != summary.ServerFQDN ||
+		output.ServerIP != summary.ServerIP ||
+		output.DownloadUUID != summary.DownloadUUID ||
 		output.Download != summary.Download ||
 		output.Upload != summary.Upload ||
 		output.DownloadRetrans != summary.DownloadRetrans ||

--- a/cmd/ndt5-client/internal/emitter/json_test.go
+++ b/cmd/ndt5-client/internal/emitter/json_test.go
@@ -206,12 +206,12 @@ func TestJSONOnSummary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if output.Client != summary.Client ||
-		output.Server != summary.Server ||
+	if output.ClientIP != summary.ClientIP ||
+		output.ServerFQDN != summary.ServerFQDN ||
 		output.Download != summary.Download ||
 		output.Upload != summary.Upload ||
 		output.DownloadRetrans != summary.DownloadRetrans ||
-		output.RTT != summary.RTT {
+		output.MinRTT != summary.MinRTT {
 		t.Fatal("OnSummary(): unexpected output")
 	}
 

--- a/cmd/ndt5-client/internal/emitter/summary.go
+++ b/cmd/ndt5-client/internal/emitter/summary.go
@@ -9,11 +9,17 @@ type ValueUnitPair struct {
 // Summary is a struct containing the values displayed to the user at
 // the end of an ndt5 test.
 type Summary struct {
-	// Server is the FQDN of the server used for this test.
-	Server string
+	// ServerFQDN is the FQDN of the server used for this test.
+	ServerFQDN string
 
-	// Client is the IP address of the client.
-	Client string
+	// ServerIP is the IP address of the server.
+	ServerIP string
+
+	// ClientIP is the IP address of the client.
+	ClientIP string
+
+	// DownloadUUID is the UUID of the download test.
+	DownloadUUID string
 
 	// Download is the download speed, in Mbit/s. This is measured at the
 	// receiver.
@@ -26,14 +32,14 @@ type Summary struct {
 	// values provided by the server during a download test.
 	DownloadRetrans ValueUnitPair
 
-	// RTT is the round-trip time of the latest measurement, in milliseconds.
-	// This is provided by the server during a download test.
-	RTT ValueUnitPair
+	// MinRTT is the minimum round-trip time reported by the server in the
+	// last Measurement of a download test, in milliseconds.
+	MinRTT ValueUnitPair
 }
 
 // NewSummary returns a new Summary struct for a given FQDN.
 func NewSummary(FQDN string) *Summary {
 	return &Summary{
-		Server: FQDN,
+		ServerFQDN: FQDN,
 	}
 }

--- a/cmd/ndt5-client/internal/emitter/summary_test.go
+++ b/cmd/ndt5-client/internal/emitter/summary_test.go
@@ -9,7 +9,7 @@ func TestNewSummary(t *testing.T) {
 	if s == nil {
 		t.Fatal("NewSummary() did not return a Summary")
 	}
-	if s.Server != "test" {
+	if s.ServerFQDN != "test" {
 		t.Fatal("NewSummary(): unexpected Server field")
 	}
 }

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -117,8 +117,16 @@ func main() {
 func makeSummary(FQDN string, result ndt5.TestResult) *emitter.Summary {
 	s := emitter.NewSummary(FQDN)
 
+	if serverIP, ok := result.Web100["NDTResult.S2C.ServerIP"]; ok {
+		s.ServerIP = serverIP
+	}
+
 	if clientIP, ok := result.Web100["NDTResult.S2C.ClientIP"]; ok {
-		s.Client = clientIP
+		s.ClientIP = clientIP
+	}
+
+	if UUID, ok := result.Web100["NDTResult.S2C.UUID"]; ok {
+		s.DownloadUUID = UUID
 	}
 
 	elapsed := result.ClientMeasuredDownload.Elapsed.Seconds()
@@ -134,13 +142,13 @@ func makeSummary(FQDN string, result ndt5.TestResult) *emitter.Summary {
 		Unit:  "Mbit/s",
 	}
 
-	// Here we use the RTT provided by the server, assuming they are
+	// Here we use the MinRTT provided by the server, assuming they are
 	// symmetrical.
-	if rtt, ok := result.Web100["TCPInfo.RTT"]; ok {
+	if rtt, ok := result.Web100["TCPInfo.MinRTT"]; ok {
 		rtt, err := strconv.ParseFloat(rtt, 64)
 		if err == nil {
-			s.RTT = emitter.ValueUnitPair{
-				// TCPInfo.RTT is in microseconds.
+			s.MinRTT = emitter.ValueUnitPair{
+				// TCPInfo.MinRTT is in microseconds.
 				Value: rtt / 1000.0,
 				Unit:  "ms",
 			}


### PR DESCRIPTION
This PR makes the same changes made at https://github.com/m-lab/ndt7-client-go/pull/42, plus `RTT` that becomes `MinRTT` (the same change will follow on the ndt7-client-go codebase) as that's the value we would like to provide to users of this summary - namely, Murakami.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt5-client-go/4)
<!-- Reviewable:end -->
