### PR TITLE
Add support for injecting access token

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"time"
 
@@ -80,6 +81,9 @@ func (cf *WSConnectionsFactory) DialEx(
 		Scheme: cf.Scheme,
 		Host:   address,
 		Path:   path,
+		// Allow injecting access token queries. If the variable is empty
+		// then this is a no-op.
+		RawQuery: os.Getenv("NDT5_ACCESS_TOKEN"),
 	}
 	headers := http.Header{}
 	headers.Add("Sec-WebSocket-Protocol", wsProtocol)


### PR DESCRIPTION
This change adds support for injecting NDT5 access tokens into the ndt5-client command.

This change only applies to ndt5+wss tests.

This change will support migrating the e2e monitoring to use this command with access tokens issued by the new locate v2/monitoring API for the target node. This will also facilitate labeling e2e test rates as originating from monitoring https://github.com/m-lab/ndt-server/issues/275

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt5-client-go/5)
<!-- Reviewable:end -->
