### PR TITLE
Change throttle flag to accept bitrate & use non-production NS url for testing

### DIFF
--- a/client.go
+++ b/client.go
@@ -264,14 +264,14 @@ const (
 )
 
 // NewClient creates a new ndt5 client instance.
-func NewClient(clientName, clientVersion string) *Client {
+func NewClient(clientName, clientVersion, nsURL string) *Client {
+	ns := mlabns.NewClient("ndt_ssl", makeUserAgent(clientName, clientVersion))
+	ns.BaseURL = nsURL
 	return &Client{
 		ClientName:      clientName,
 		ClientVersion:   clientVersion,
 		ProtocolFactory: new(ProtocolFactory5),
-		MLabNSClient: mlabns.NewClient(
-			"ndt_ssl", makeUserAgent(clientName, clientVersion),
-		),
+		MLabNSClient:    ns,
 	}
 }
 

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -34,6 +34,7 @@ var (
 		Options: []string{"human", "json"},
 		Value:   "human",
 	}
+	flagNSURL    = flag.String("ns-url", "https://locate.measurementlab.net/", "Base URL to locate service")
 	flagThrottle = flag.Int64("throttle", 1<<20, "Throttle connections to given rate for testing")
 	flagTimeout  = flag.Duration(
 		"timeout", defaultTimeout, "time after which the test is aborted")
@@ -70,7 +71,7 @@ func main() {
 	if *flagVerbose {
 		factory5.ObserverFactory = new(verboseFrameReadWriteObserverFactory)
 	}
-	client := ndt5.NewClient(clientName, clientVersion)
+	client := ndt5.NewClient(clientName, clientVersion, *flagNSURL)
 	client.ProtocolFactory = factory5
 	client.FQDN = *flagHostname
 

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -34,7 +34,7 @@ var (
 		Options: []string{"human", "json"},
 		Value:   "human",
 	}
-	flagThrottle = flag.Bool("throttle", false, "Throttle connections for testing")
+	flagThrottle = flag.Int64("throttle", 1<<20, "Throttle connections to given rate for testing")
 	flagTimeout  = flag.Duration(
 		"timeout", defaultTimeout, "time after which the test is aborted")
 	flagVerbose = flag.Bool("verbose", false, "Log ndt5 messages")
@@ -57,8 +57,8 @@ func init() {
 func main() {
 	flag.Parse()
 	var dialer ndt5.NetDialer = new(net.Dialer)
-	if *flagThrottle {
-		dialer = trafficshaping.NewDialer()
+	if *flagThrottle > 0 {
+		dialer = trafficshaping.NewDialerWithBitrate(*flagThrottle)
 	}
 	factory5 := ndt5.NewProtocolFactory5()
 	switch flagProtocol.Value {

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -35,7 +35,7 @@ var (
 		Value:   "human",
 	}
 	flagNSURL    = flag.String("ns-url", "https://locate.measurementlab.net/", "Base URL to locate service")
-	flagThrottle = flag.Int64("throttle", 1<<20, "Throttle connections to given rate for testing")
+	flagThrottle = flag.Int64("throttle", 0, "Throttle connections to given rate for testing")
 	flagTimeout  = flag.Duration(
 		"timeout", defaultTimeout, "time after which the test is aborted")
 	flagVerbose = flag.Bool("verbose", false, "Log ndt5 messages")

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -35,7 +35,7 @@ var (
 		Value:   "human",
 	}
 	flagNSURL    = flag.String("ns-url", "https://locate.measurementlab.net/", "Base URL to locate service")
-	flagThrottle = flag.Int64("throttle", 0, "Throttle connections to given rate for testing")
+	flagThrottle = flag.Int64("throttle", 0, "Throttle connections to given rate for testing (bits/sec)")
 	flagTimeout  = flag.Duration(
 		"timeout", defaultTimeout, "time after which the test is aborted")
 	flagVerbose = flag.Bool("verbose", false, "Log ndt5 messages")

--- a/cmd/ndt5-client/main_test.go
+++ b/cmd/ndt5-client/main_test.go
@@ -30,7 +30,9 @@ func TestIntegrationMainWSS(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	*flagThrottle = true // be gentle on CI servers
+	// Do not use production servers for CI.
+	*flagHostname = "ndt-mlab4-lga0t.mlab-sandbox.measurement-lab.org"
+	*flagThrottle = 1 << 18 // be gentle on CI servers
 	code := m.Run()
 	os.Exit(code)
 }

--- a/cmd/ndt5-client/main_test.go
+++ b/cmd/ndt5-client/main_test.go
@@ -31,7 +31,7 @@ func TestIntegrationMainWSS(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	// Do not use production servers for CI.
-	*flagHostname = "ndt-mlab4-lga0t.mlab-sandbox.measurement-lab.org"
+	*flagNSURL = "https://mlab-sandbox.appspot.com/"
 	*flagThrottle = 1 << 18 // be gentle on CI servers
 	code := m.Run()
 	os.Exit(code)


### PR DESCRIPTION
This is a breaking change to the `ndt5-client -throttle` flag. Instead of a bool, it now accepts a bitrate.

This change adds a new flag for specifying the mlab-ns base url. This is to override the production default during unit testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt5-client-go/6)
<!-- Reviewable:end -->
