### PR TITLE
Support non-zero exit codes on error and warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+- 1.13
+
+install:
+- go get -v -t ./...
+- go get github.com/mattn/goveralls
+
+script:
+- go vet ./...
+- go test ./... -cover=1 -coverprofile=_c.cov
+- go test ./... -race
+- $GOPATH/bin/goveralls -service=travis-ci -coverprofile=_c.cov

--- a/client_test.go
+++ b/client_test.go
@@ -21,7 +21,7 @@ func TestIntegrationClientRaw(t *testing.T) {
 	protocolFactory.ConnectionsFactory = ndt5.NewRawConnectionsFactory(
 		trafficshaping.NewDialer(),
 	)
-	client := ndt5.NewClient(clientName, clientVersion)
+	client := ndt5.NewClient(clientName, clientVersion, "https://mlab-sandbox.appspot.com")
 	client.ProtocolFactory = protocolFactory
 	out, err := client.Start(context.Background())
 	if err != nil {
@@ -40,7 +40,7 @@ func TestIntegrationClientWSS(t *testing.T) {
 	protocolFactory.ConnectionsFactory = ndt5.NewWSConnectionsFactory(
 		trafficshaping.NewDialer(),
 	)
-	client := ndt5.NewClient(clientName, clientVersion)
+	client := ndt5.NewClient(clientName, clientVersion, "https://mlab-sandbox.appspot.com")
 	client.ProtocolFactory = protocolFactory
 	out, err := client.Start(context.Background())
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -12,7 +12,7 @@ import (
 func Example() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	client := ndt5.NewClient("ndt5-client-go-example", "0.1.0")
+	client := ndt5.NewClient("ndt5-client-go-example", "0.1.0", "https://locate.measurementlab.net")
 	ch, err := client.Start(ctx)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This change preserves current behavior and adds two new flags to provide callers with the option of specifying an exit code for error and warning conditions during a measurement.

This change also fixes two unit tests missed from the last pr.

This change also adds a basic .travis.yml config to run unit tests with coverage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt5-client-go/7)
<!-- Reviewable:end -->
