### PR TITLE
Vendor mlabns package

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/m-lab/ndt7-client-go/mlabns"
+	"github.com/m-lab/ndt5-client-go/mlabns"
 )
 
 // NetDialer is a network dialer.

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,4 @@ require (
 	github.com/google/martian/v3 v3.0.0
 	github.com/gorilla/websocket v1.4.1
 	github.com/m-lab/go v1.4.0
-	github.com/m-lab/ndt7-client-go v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -88,15 +88,8 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/m-lab/go v1.2.0/go.mod h1:FcVx/N8dL5J5TVQ2L0d8/cAw/ljR6fhwZqvqZHrb5/Q=
 github.com/m-lab/go v1.4.0 h1:Au2Vt15+H8oOd3xYZFfW3gK86GRciKlfGJs/FzsJwK4=
 github.com/m-lab/go v1.4.0/go.mod h1:f22d1CtoFIho8yt0wPNYo0Lx5h8YfgRW4+1pzQTeQRw=
-github.com/m-lab/ndt-server v0.13.4 h1:0rjWbZsor6/CRxOMlWxWEq1I7GUWrNCTM6//OFNC3Yo=
-github.com/m-lab/ndt-server v0.13.4/go.mod h1:ZLVRCEbCBkhh0pwNjnLpwaZnHOHGEH76H/fzIIVFRWw=
-github.com/m-lab/ndt7-client-go v0.2.0 h1:I+BV/F9/52wh2czIFULsJjyd4N7kKjwGFMpvCykLNaY=
-github.com/m-lab/ndt7-client-go v0.2.0/go.mod h1:dPCMzEUyVKj/RT8+42LXOFvvioHxcNsesRAFkaq3NjY=
-github.com/m-lab/tcp-info v1.3.0 h1:bL8ElOp5Sxc5e1W86swMv5zjh6/y1Y9qT7eEOgJnzq4=
-github.com/m-lab/tcp-info v1.3.0/go.mod h1:bkvI4qbjB6QVC2tsLSHqf5OnIYcmuLEVjo7+8YA56Kg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/mlabns/mlabns.go
+++ b/mlabns/mlabns.go
@@ -1,0 +1,124 @@
+// Package mlabns implements a simple mlab-ns client.
+package mlabns
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// HttpRequestMaker is the type of the function that
+// creates a new HTTP request for us.
+type HttpRequestMaker = func(
+	method, url string, body io.Reader) (*http.Request, error)
+
+// DefaultTimeout is the default value for Client.Timeout
+const DefaultTimeout = 14 * time.Second
+
+// Client is an mlabns client.
+type Client struct {
+	// BaseURL is the optional base URL for contacting mlabns. This is
+	// initialized in NewClient, but you may override it.
+	BaseURL string
+
+	// HTTPClient is the client that will perform the request. By default
+	// it is initialized to http.DefaultClient. You may override it for
+	// testing purpses and more generally whenever you are not satisfied
+	// with the behaviour of the default HTTP client.
+	HTTPClient *http.Client
+
+	// Timeout is the optional maximum amount of time we're willing to wait
+	// for mlabns to respond. This setting is initialized by NewClient to its
+	// default value, but you may override it.
+	Timeout time.Duration
+
+	// Tool is the mandatory tool to use. This is initialized by NewClient.
+	Tool string
+
+	// UserAgent is the mandatory user agent to be used. Also this
+	// field is initialized by NewClient.
+	UserAgent string
+
+	// RequestMaker is the function that creates a request. This is
+	// initialized in NewClient, but you may override it.
+	RequestMaker HttpRequestMaker
+}
+
+// baseURL is the default base URL.
+const baseURL = "https://locate.measurementlab.net/"
+
+// NewClient creates a new Client instance with mandatory userAgent, and tool
+// name. For running ndt7, use "ndt7" as the tool name.
+func NewClient(tool, userAgent string) *Client {
+	return &Client{
+		BaseURL:      baseURL,
+		HTTPClient:   http.DefaultClient,
+		Timeout:      DefaultTimeout,
+		RequestMaker: http.NewRequest,
+		Tool:         tool,
+		UserAgent:    userAgent,
+	}
+}
+
+// serverEntry describes a mlab server.
+type serverEntry struct {
+	// FQDN is the the FQDN of the server.
+	FQDN string `json:"fqdn"`
+}
+
+// ErrNoAvailableServers is returned when there are no available servers. A
+// background client should treat this error specially as described in the
+// specification of the ndt7 protocol.
+var ErrNoAvailableServers = errors.New("No available M-Lab servers")
+
+// ErrQueryFailed indicates a non-200 status code.
+var ErrQueryFailed = errors.New("mlabns returned non-200 status code")
+
+// doGET is an internal function used to perform the request.
+func (c *Client) doGET(ctx context.Context, URL string) ([]byte, error) {
+	request, err := c.RequestMaker("GET", URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("User-Agent", c.UserAgent)
+	requestctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+	request = request.WithContext(requestctx)
+	response, err := c.HTTPClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode == 204 {
+		return nil, ErrNoAvailableServers
+	}
+	if response.StatusCode != 200 {
+		return nil, ErrQueryFailed
+	}
+	return ioutil.ReadAll(response.Body)
+}
+
+// Query returns the FQDN of a nearby mlab server. Returns an error on
+// failure and the server FQDN on success.
+func (c *Client) Query(ctx context.Context) (string, error) {
+	URL, err := url.Parse(c.BaseURL)
+	if err != nil {
+		return "", err
+	}
+	URL.Path = c.Tool
+	data, err := c.doGET(ctx, URL.String())
+	if err != nil {
+		return "", err
+	}
+	var server serverEntry
+	err = json.Unmarshal(data, &server)
+	if err != nil {
+		return "", err
+	}
+	return server.FQDN, nil
+}

--- a/mlabns/mlabns_test.go
+++ b/mlabns/mlabns_test.go
@@ -1,0 +1,165 @@
+package mlabns
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// reponseBody is a fake HTTP response body.
+type reponseBody struct {
+	reader io.Reader
+}
+
+// newResponseBody creates a new response body.
+func newResponseBody(data []byte) io.ReadCloser {
+	return &reponseBody{
+		reader: bytes.NewReader(data),
+	}
+}
+
+// Read reads the response body.
+func (r *reponseBody) Read(p []byte) (n int, err error) {
+	return r.reader.Read(p)
+}
+
+// Close closes the response body.
+func (r *reponseBody) Close() error {
+	return nil
+}
+
+type httpTransport struct {
+	Response *http.Response
+	Error    error
+}
+
+// newHTTPClient returns a mocked *http.Client.
+func newHTTPClient(code int, body []byte, err error) *http.Client {
+	return &http.Client{
+		Transport: &httpTransport{
+			Error: err,
+			Response: &http.Response{
+				Body:       newResponseBody(body),
+				StatusCode: code,
+			},
+		},
+	}
+}
+
+func (r *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Cannot be more concise than this (i.e. `return r.Error, r.Response`) because
+	// http.Client.Do warns if both Error and Response are non nil
+	if r.Error != nil {
+		return nil, r.Error
+	}
+	return r.Response, nil
+}
+
+const (
+	toolName  = "ndt7"
+	userAgent = "ndt7-client-go/0.1.0"
+)
+
+func TestQueryCommonCase(t *testing.T) {
+	const expectedFQDN = "ndt7-mlab1-nai01.measurementlab.org"
+	client := NewClient(toolName, userAgent)
+	client.HTTPClient = newHTTPClient(
+		200, []byte(fmt.Sprintf(`{"fqdn":"%s"}`, expectedFQDN)), nil,
+	)
+	fqdn, err := client.Query(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fqdn != expectedFQDN {
+		t.Fatal("Not the FQDN we were expecting")
+	}
+}
+
+func TestQueryURLError(t *testing.T) {
+	client := NewClient(toolName, userAgent)
+	client.BaseURL = "\t" // breaks the parser
+	_, err := client.Query(context.Background())
+	if err == nil {
+		t.Fatal("We were expecting an error here")
+	}
+}
+
+func TestQueryNewRequestError(t *testing.T) {
+	mockedError := errors.New("mocked error")
+	client := NewClient(toolName, userAgent)
+	client.RequestMaker = func(
+		method, url string, body io.Reader) (*http.Request, error,
+	) {
+		return nil, mockedError
+	}
+	_, err := client.Query(context.Background())
+	if err != mockedError {
+		t.Fatal("Not the error we were expecting")
+	}
+}
+
+func TestQueryNetworkError(t *testing.T) {
+	mockedError := errors.New("mocked error")
+	client := NewClient(toolName, userAgent)
+	client.HTTPClient = newHTTPClient(
+		0, []byte{}, mockedError,
+	)
+	_, err := client.Query(context.Background())
+	// According to Go docs, the return value of http.Client.Do is always
+	// of type `*url.Error` and wraps the original error.
+	if err.(*url.Error).Err != mockedError {
+		t.Fatal("Not the error we were expecting")
+	}
+}
+
+func TestQueryInvalidStatusCode(t *testing.T) {
+	client := NewClient(toolName, userAgent)
+	client.HTTPClient = newHTTPClient(
+		500, []byte{}, nil,
+	)
+	_, err := client.Query(context.Background())
+	if err != ErrQueryFailed {
+		t.Fatal("Not the error we were expecting")
+	}
+}
+
+func TestQueryJSONParseError(t *testing.T) {
+	client := NewClient(toolName, userAgent)
+	client.HTTPClient = newHTTPClient(
+		200, []byte("{"), nil,
+	)
+	_, err := client.Query(context.Background())
+	if err == nil {
+		t.Fatal("We expected an error here")
+	}
+}
+
+func TestQueryNoServers(t *testing.T) {
+	client := NewClient(toolName, userAgent)
+	client.HTTPClient = newHTTPClient(
+		204, []byte(""), nil,
+	)
+	_, err := client.Query(context.Background())
+	if err != ErrNoAvailableServers {
+		t.Fatal("Not the error we were expecting")
+	}
+}
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+	client := NewClient(toolName, userAgent)
+	fqdn, err := client.Query(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fqdn == "" {
+		t.Fatal("unexpected empty fqdn")
+	}
+}

--- a/mlabns/mlabns_test.go
+++ b/mlabns/mlabns_test.go
@@ -61,8 +61,8 @@ func (r *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 const (
-	toolName  = "ndt7"
-	userAgent = "ndt7-client-go/0.1.0"
+	toolName  = "ndt5"
+	userAgent = "ndt5-client-go/0.1.0"
 )
 
 func TestQueryCommonCase(t *testing.T) {

--- a/mlabns/mlabns_test.go
+++ b/mlabns/mlabns_test.go
@@ -61,7 +61,7 @@ func (r *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 const (
-	toolName  = "ndt5"
+	toolName  = "ndt_ssl"
 	userAgent = "ndt5-client-go/0.1.0"
 )
 


### PR DESCRIPTION
This package does not exist anymore in ndt7-client-go. It will eventually be replaced by m-lab/locate here, too.
This is just a temporary solution to keep ndt5-client-go building for people not using go modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt5-client-go/12)
<!-- Reviewable:end -->
