### PR TITLE
Make sure we're not dividing by zero

### DIFF
--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -184,7 +184,7 @@ func makeSummary(FQDN string, result ndt5.TestResult) *emitter.Summary {
 			// happen on the M-Lab servers, it's been reported in some custom
 			// deployments. In this case, we don't add the retransmission to
 			// the summary.
-			if err1 == nil && err2 == nil && retrans > 0 && sent > 0 {
+			if err1 == nil && err2 == nil && sent > 0 {
 				s.DownloadRetrans = emitter.ValueUnitPair{
 					Value: retrans / sent * 100,
 					Unit:  "%",

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -179,11 +179,10 @@ func makeSummary(FQDN string, result ndt5.TestResult) *emitter.Summary {
 			retrans, err1 := strconv.ParseFloat(bytesRetrans, 64)
 			sent, err2 := strconv.ParseFloat(bytesSent, 64)
 
-			// If BytesRetrans and BytesSent aren't both > 0, something went
-			// wrong while getting the TCPInfo results. While this should never
-			// happen on the M-Lab servers, it's been reported in some custom
-			// deployments. In this case, we don't add the retransmission to
-			// the summary.
+			// If BytesSent isn't > 0, something went wrong while getting the
+			// TCPInfo results. While this should never happen on M-Lab's
+			// servers, it's been reported in some custom deployments.
+			// In this case, we don't add the retransmission to the summary.
 			if err1 == nil && err2 == nil && sent > 0 {
 				s.DownloadRetrans = emitter.ValueUnitPair{
 					Value: retrans / sent * 100,

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -128,7 +129,9 @@ func main() {
 	}
 
 	summary := makeSummary(client.FQDN, client.Result)
-	e.OnSummary(summary)
+	err = e.OnSummary(summary)
+	err = errors.New("test")
+	rtx.Must(err, "emitter.OnSummary failed")
 	os.Exit(exitCode)
 }
 
@@ -178,7 +181,7 @@ func makeSummary(FQDN string, result ndt5.TestResult) *emitter.Summary {
 			retrans, err1 := strconv.ParseFloat(bytesRetrans, 64)
 			sent, err2 := strconv.ParseFloat(bytesSent, 64)
 
-			if err1 == nil && err2 == nil {
+			if err1 == nil && err2 == nil && retrans > 0 && sent > 0 {
 				s.DownloadRetrans = emitter.ValueUnitPair{
 					Value: retrans / sent * 100,
 					Unit:  "%",

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -179,6 +179,11 @@ func makeSummary(FQDN string, result ndt5.TestResult) *emitter.Summary {
 			retrans, err1 := strconv.ParseFloat(bytesRetrans, 64)
 			sent, err2 := strconv.ParseFloat(bytesSent, 64)
 
+			// If BytesRetrans and BytesSent aren't both > 0, something went
+			// wrong while getting the TCPInfo results. While this should never
+			// happen on the M-Lab servers, it's been reported in some custom
+			// deployments. In this case, we don't add the retransmission to
+			// the summary.
 			if err1 == nil && err2 == nil && retrans > 0 && sent > 0 {
 				s.DownloadRetrans = emitter.ValueUnitPair{
 					Value: retrans / sent * 100,

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/hex"
-	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -130,7 +129,6 @@ func main() {
 
 	summary := makeSummary(client.FQDN, client.Result)
 	err = e.OnSummary(summary)
-	err = errors.New("test")
 	rtx.Must(err, "emitter.OnSummary failed")
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
Also, make sure errors from `OnSummary` aren't ignored.

If `BytesSent` is zero, there is no panic but the result is non-marshallable (I suspect `+Inf`?) and makes `OnSummary` fail when `-format=json`. Since errors from `OnSummary` are not checked, it fails silently.

It's still unclear why TCPInfo.BytesSent/BytesReceived/BytesRetrans can be zero in some cases, but it definitely happens (https://github.com/m-lab/ndt5-client-go/issues/11).

This was originally reported as a Murakami issue (https://github.com/m-lab/murakami/issues/108).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt5-client-go/15)
<!-- Reviewable:end -->
