### PR TITLE
Update to go1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 
 go:
-- 1.13
+- 1.18
 
 install:
 - go get -v -t ./...
-- go get github.com/mattn/goveralls
+- go install github.com/mattn/goveralls@latest
 
 script:
 - go vet ./...

--- a/cmd/ndt5-client/main.go
+++ b/cmd/ndt5-client/main.go
@@ -43,6 +43,8 @@ var (
 	flagExitOnErr  = flag.Int("exit-on-error", 0, "Exit code to use for errors")
 	flagExitOnWarn = flag.Int("exit-on-warning", 0, "Exit code to use when for warnings")
 	flagService    = flagx.URL{}
+
+	osExit = os.Exit // Allow mocking os.Exit for unit tests.
 )
 
 func init() {
@@ -130,7 +132,7 @@ func main() {
 	summary := makeSummary(client.FQDN, client.Result)
 	err = e.OnSummary(summary)
 	rtx.Must(err, "emitter.OnSummary failed")
-	os.Exit(exitCode)
+	osExit(exitCode)
 }
 
 func makeSummary(FQDN string, result ndt5.TestResult) *emitter.Summary {

--- a/cmd/ndt5-client/main_test.go
+++ b/cmd/ndt5-client/main_test.go
@@ -9,6 +9,12 @@ func TestIntegrationMainRaw(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	origExit = osExit
+	osExit = func(int) {}
+	defer func() {
+		osExit = origExit
+	}()
+
 	origValue := flagProtocol.Value
 	flagProtocol.Value = "ndt5"
 	defer func() {
@@ -21,6 +27,12 @@ func TestIntegrationMainWSS(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	origExit = osExit
+	osExit = func(int) {}
+	defer func() {
+		osExit = origExit
+	}()
+
 	origValue := flagProtocol.Value
 	flagProtocol.Value = "ndt5+wss"
 	defer func() {

--- a/cmd/ndt5-client/main_test.go
+++ b/cmd/ndt5-client/main_test.go
@@ -9,7 +9,7 @@ func TestIntegrationMainRaw(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	origExit = osExit
+	origExit := osExit
 	osExit = func(int) {}
 	defer func() {
 		osExit = origExit
@@ -27,7 +27,7 @@ func TestIntegrationMainWSS(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	origExit = osExit
+	origExit := osExit
 	osExit = func(int) {}
 	defer func() {
 		osExit = origExit

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/m-lab/ndt5-client-go
 
-go 1.13
+go 1.18
 
 require (
 	github.com/google/martian/v3 v3.1.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/m-lab/go v0.1.43
 )
+
+require github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/m-lab/go v0.1.43
 )
 
-require github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 // indirect
+require github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,7 +92,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.1.0 h1:wCKgOCHuUEVfsaQLpPSJb7VdYCdTVZQAuOdYm1yc/60=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -120,11 +119,9 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/m-lab/go v0.1.43 h1:AKmrhhi5a5rUL9nNMo0YNLSJLNFLfV5PmdAXqRCBGE8=
 github.com/m-lab/go v0.1.43/go.mod h1:+C0ZBlRKsF7wIbqHRtiL8bqD6cOwlZXDTK/KQ7Iv434=
@@ -368,7 +365,6 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This change updates the go.mod and travis configuration to use go1.18.

Part of:
* https://github.com/m-lab/dev-tracker/issues/735

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt5-client-go/17)
<!-- Reviewable:end -->
