### PR TITLE
Separate coveralls report in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ script:
 - go vet ./...
 - go test ./... -cover=1 -coverprofile=_c.cov
 - go test ./... -race
+
+after_script:
 - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=_c.cov


### PR DESCRIPTION
After updating this repo to use go1.18 https://github.com/m-lab/ndt5-client-go/pull/17 the merged build failed repeatedly due to the sandbox integration tests. And, once they passed (after retry) the coveralls report failed due to a duplicate job id.

This change separates the coveralls report so its error does not cause the build to fail if the tests otherwise pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt5-client-go/18)
<!-- Reviewable:end -->
